### PR TITLE
Clang code warning clean up

### DIFF
--- a/hougeo/json.h
+++ b/hougeo/json.h
@@ -203,6 +203,7 @@ namespace hougeo
 		// Writer ==================================================
 		struct Writer
 		{
+			virtual                                   ~Writer(){};
 			virtual void                       jsonBeginArray() = 0;
 			virtual void                         jsonEndArray() = 0;
 			virtual void                         jsonBeginMap() = 0;

--- a/hougeo/ttl/exception.hpp
+++ b/hougeo/ttl/exception.hpp
@@ -18,7 +18,7 @@ namespace ttl
 	struct exception : std::runtime_error
 	{
 		exception() : std::runtime_error("ttl error") {}
-		exception( char* msg ) :  std::runtime_error(msg) {}
+		exception( const char* msg ) :  std::runtime_error(msg) {}
 	};
 };
 


### PR DESCRIPTION
(1) const char* in exception message
(2) Virtual destructor in class with virtual methods (Writer)